### PR TITLE
bug: remove additional servers wrapper from memory model

### DIFF
--- a/pkg/apigee/v1/apiproxymodel_test.go
+++ b/pkg/apigee/v1/apiproxymodel_test.go
@@ -1,0 +1,67 @@
+//  Copyright 2024 Google LLC
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package v1
+
+import (
+	"github.com/apigee/apigee-go-gen/pkg/utils"
+	"github.com/go-errors/errors"
+	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// this test round-trips the input YAML through the in-memory model, and back to YAML
+// if there are no errors, and the output YAML matches the input, it means that the in-memory
+// model was hydrated correctly from the input YAML
+
+func TestNewAPIProxyModel(t *testing.T) {
+
+	tests := []struct {
+		name string
+	}{
+		{
+			"simple",
+		},
+	}
+	for _, tt := range tests {
+		ttDir := filepath.Join("testdata", "yaml-first", tt.name)
+		t.Run(tt.name, func(t *testing.T) {
+			inputFile := filepath.Join(ttDir, "apiproxy.yaml")
+			expFile := filepath.Join(ttDir, "exp-apiproxy.yaml")
+
+			if _, err := os.Stat(expFile); errors.Is(err, os.ErrNotExist) {
+				//if there is no expected file, use the input itself as expected
+				expFile = inputFile
+			}
+
+			outFile := filepath.Join(ttDir, "out-apiproxy.yaml")
+
+			model, err := NewAPIProxyModel(inputFile)
+			require.NoError(t, err)
+
+			outData, err := model.YAML()
+			require.NoError(t, err)
+
+			//for convenience write the output to disk (makes it easier to diff)
+			err = os.WriteFile(outFile, outData, os.ModePerm)
+			require.NoError(t, err)
+
+			expData := utils.MustReadFileBytes(expFile)
+
+			require.YAMLEq(t, string(expData), string(outData))
+		})
+	}
+}

--- a/pkg/apigee/v1/loadbalancer.go
+++ b/pkg/apigee/v1/loadbalancer.go
@@ -17,8 +17,8 @@ package v1
 import "fmt"
 
 type LoadBalancer struct {
-	Algorithm string   `xml:"Algorithm,omitempty"`
-	Servers   *Servers `xml:"Servers"`
+	Algorithm string      `xml:"Algorithm,omitempty"`
+	Servers   *ServerList `xml:"Server,omitempty"`
 
 	UnknownNode AnyList `xml:",any"`
 }

--- a/pkg/apigee/v1/servers.go
+++ b/pkg/apigee/v1/servers.go
@@ -18,24 +18,13 @@ import "fmt"
 
 type ServerList []*Server
 
-type Servers struct {
-	List ServerList `xml:"Server,omitempty"`
-
-	UnknownNode AnyList `xml:",any"`
-}
-
-func ValidateServers(v *Servers, path string) []error {
+func ValidateServers(v *ServerList, path string) []error {
 	if v == nil {
 		return nil
 	}
 
-	subPath := fmt.Sprintf("%s.Servers", path)
-	if len(v.UnknownNode) > 0 {
-		return []error{&UnknownNodeError{subPath, v.UnknownNode[0]}}
-	}
-
-	for index, vv := range v.List {
-		errs := ValidateServer(vv, fmt.Sprintf("%s.%v", subPath, index))
+	for i, vv := range *v {
+		errs := ValidateServer(vv, fmt.Sprintf("%s.Servers.%v", path, i))
 		if len(errs) > 0 {
 			return errs
 		}

--- a/pkg/apigee/v1/testdata/.gitignore
+++ b/pkg/apigee/v1/testdata/.gitignore
@@ -1,0 +1,14 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http:#www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+out-*.yaml

--- a/pkg/apigee/v1/testdata/yaml-first/simple/apiproxy.yaml
+++ b/pkg/apigee/v1/testdata/yaml-first/simple/apiproxy.yaml
@@ -1,0 +1,39 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http:#www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+APIProxy:
+  .revision: 1
+  .name: swagger-petstore
+Policies: []
+ProxyEndpoints:
+  - ProxyEndpoint:
+      .name: default
+      Flows:
+        - Flow:
+            .name: listPets
+            Condition: (proxy.pathsuffix MatchesPath "/pets") and (request.verb = "GET")
+        - Flow:
+            .name: showPetById
+            Condition: (proxy.pathsuffix MatchesPath "/pets/*") and (request.verb = "GET")
+      HTTPProxyConnection:
+        BasePath: /v1
+      RouteRule:
+        .name: default
+        TargetEndpoint: default
+TargetEndpoints:
+  - TargetEndpoint:
+      .name: default
+      HTTPTargetConnection:
+        LoadBalancer:
+          Server:
+            .name: TS-swagger-petstore


### PR DESCRIPTION
The in-memory model of the API Proxy bundle had incorrectly set an extra layer for the target servers like this

<LoadBalancer>
  <Servers>
    <Server name="foo" />
    <Server name="bar" />
  </Servers>
</LoadBalancer>

This is not correct, the correct way is

<LoadBalancer>
  <Server name="foo" />
  <Server name="bar" />
</LoadBalancer>