### PR TITLE
fix: modify install script to prioritize stable releases

### DIFF
--- a/install
+++ b/install
@@ -88,14 +88,43 @@ checkCurrentVersion() {
   fi
 }
 
+
+sortSemver() {
+  local lines=""
+  while read version; do
+    if [[ -z "${lines}" ]] ; then
+      lines=$(printf '%s' "${version}")
+    else
+      lines=$(printf '%s\n%s' "${lines}" "${version}")
+    fi
+  done
+  echo "$lines" | sed -r 's:^v::' | sed -r 's:-:~:' | sort -r -V | sed -r 's:^:v:' | sed -r 's:~:-:'
+}
+
+pickLatestRelease() {
+  local first=""
+  while read version; do
+    first="${version}"
+    if [[ "${version}" != *"-"* ]] ; then
+      echo "${version}"
+      return
+    fi
+  done
+  echo "${first}"
+}
+
+getReleasedTags() {
+  local releaseUrl="${1}"
+  curl -s "${releaseUrl}" | grep "tag_name" | sed -r 's;^[^:]+:[^"]*"([^"]+)".*;\1;'
+}
+
 getLatestRelease() {
   local releaseUrl="https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/releases"
   local latest_release=""
 
-  latest_release=$(curl -s $releaseUrl | grep \"tag_name\" | grep -v rc | awk 'NR==1{print $2}' |  sed -n 's/\"\(.*\)\",/\1/p')
+  latest_release=$(getReleasedTags $releaseUrl | sortSemver | pickLatestRelease)
   ret_val=$latest_release
 }
-
 
 createTmpDir() {
    ret_val=$(mktemp -dt ${BINARY_FILENAME}-tmp)


### PR DESCRIPTION
Before, the script was picking whatever was the most recent released tag. This is not necessarily correct, as you can have tags for betas, and release candidates. We don't want customers installing the "latest" and end up using an unstable build.

Now, we sort all the tags by the semantic version number, and then we pick the first stable one (not containing a dash). If we can't find any stable one, we pick the top one in the list.