### PR TITLE
feat: publish docker image to ghcr.io

### DIFF
--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -1,0 +1,21 @@
+name: publish-docker-image
+on:
+  workflow_dispatch:
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: docker login
+        run: docker login ghcr.io -u "${{ github.actor }}" -p "${{ secrets.GITHUB_TOKEN }}"
+      - name: checkout source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: docker build and push
+        env:
+          GIT_REPO: ${{ github.repository }}
+        run: ./build-docker.sh push

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@
 
 FROM golang:1.21 as builder
 
+ARG GIT_REPO
 ARG GIT_TAG
 ARG GIT_COMMIT
 ARG BUILD_TIMESTAMP
@@ -26,17 +27,23 @@ RUN ./build.sh
 
 FROM golang:1.21
 
-LABEL org.opencontainers.image.url='https://github.com/apigee/apigee-go-gen' \
-      org.opencontainers.image.documentation='https://github.com/apigee/apigee-go-gen' \
-      org.opencontainers.image.source='https://github.com/apigee/apigee-go-gen' \
+COPY LICENSE /
+
+COPY --from=builder /src/bin/* /usr/local/bin/
+
+ARG GIT_REPO
+ARG GIT_TAG
+ARG GIT_COMMIT
+ARG BUILD_TIMESTAMP
+
+LABEL org.opencontainers.image.url="https://github.com/${GIT_REPO}" \
+      org.opencontainers.image.documentation="https://github.com/${GIT_REPO}" \
+      org.opencontainers.image.source="https://github.com/${GIT_REPO}" \
+      org.opencontainers.image.version="${GIT_TAG}" \
+      org.opencontainers.image.revision="${GIT_COMMIT}" \
       org.opencontainers.image.vendor='Google LLC' \
       org.opencontainers.image.licenses='Apache-2.0' \
       org.opencontainers.image.description='This is a tool for generating Apigee bundles and shared flows'
-
-COPY LICENSE /
-COPY LICENSE-3RD-PARTY /
-
-COPY --from=builder /src/bin/* /usr/local/bin/
 
 ENTRYPOINT [ "apigee-go-gen" ]
 

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -16,4 +16,69 @@
 #
 
 
-docker build -t apigee/apigee-go-gen .
+sortSemver() {
+  local lines=""
+  while read version; do
+    if [[ -z "${lines}" ]] ; then
+      lines=$(printf '%s' "${version}")
+    else
+      lines=$(printf '%s\n%s' "${lines}" "${version}")
+    fi
+  done
+  echo "$lines" | sed -r 's:^v::' | sed -r 's:-:~:' | sort -r -V | sed -r 's:^:v:' | sed -r 's:~:-:'
+}
+
+pickLatestRelease() {
+  local first=""
+  while read version; do
+    first="${version}"
+    if [[ "${version}" != *"-"* ]] ; then
+      echo "${version}"
+      return
+    fi
+  done
+  echo "${first}"
+}
+
+getReleasedTags() {
+  git tag --list  | grep "^v"
+}
+
+getLatestRelease() {
+  echo "$(getReleasedTags | sortSemver | pickLatestRelease)"
+}
+
+
+REGISTRY="${REGISTRY:-ghcr.io}"
+GIT_REPO="${GIT_REPO:-apigee/apigee-go-gen}"
+BUILD_TIMESTAMP=$(date "+%s")
+GIT_COMMIT=$(git rev-parse --short HEAD)
+GIT_TAG=$(git describe --tags --abbrev=0)
+LATEST_TAG="$(getLatestRelease)"
+
+if [[ "${LATEST_TAG}" == "${GIT_TAG}" ]] ; then
+  BUILD_TAG="latest"
+else
+  BUILD_TAG="${GIT_TAG}"
+fi
+
+
+echo "LATEST_TAG=${LATEST_TAG}"
+echo "BUILD_TAG=${BUILD_TAG}"
+echo "GIT_TAG=${GIT_TAG}"
+echo "GIT_COMMIT=${GIT_COMMIT}"
+
+docker build -t "${REGISTRY}/${GIT_REPO}:${BUILD_TAG}" \
+       -t "${REGISTRY}/${GIT_REPO}:${GIT_TAG}" \
+       -t "${REGISTRY}/${GIT_REPO}:${GIT_COMMIT}" \
+       --build-arg "GIT_REPO=${GIT_REPO}" \
+       --build-arg="GIT_TAG=${GIT_TAG}" \
+       --build-arg="GIT_COMMIT=${GIT_COMMIT}" \
+       --build-arg="BUILD_TIMESTAMP=${BUILD_TIMESTAMP}" \
+       .
+
+if [ "${1}" == "push" ] ; then
+  docker push "${REGISTRY}/${GIT_REPO}:${BUILD_TAG}"
+  docker push "${REGISTRY}/${GIT_REPO}:${GIT_TAG}"
+  docker push "${REGISTRY}/${GIT_REPO}:${GIT_COMMIT}"
+fi


### PR DESCRIPTION
Create workflow to build and publish docker image to ghcr.io.

Also, make sure that we only tag stable releases as 'latest'. This way we can build docker images for unstable beta, or release candidates, but still keep latest tagged image pointing to the most recent stable release.