### PR TITLE
feat: update docker build for multi-arch

### DIFF
--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -18,4 +18,4 @@ jobs:
       - name: docker build and push
         env:
           GIT_REPO: ${{ github.repository }}
-        run: ./build-docker.sh push
+        run: ./docker-build-push.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,36 +14,21 @@
 #  limitations under the License.
 #
 
-FROM golang:1.21 as builder
-
-ARG GIT_REPO
-ARG GIT_TAG
-ARG GIT_COMMIT
-ARG BUILD_TIMESTAMP
+FROM --platform=$BUILDPLATFORM golang:alpine as builder
+RUN apk update && apk add --no-cache git
 
 ADD ./ /src
 WORKDIR /src
-RUN ./build.sh
 
-FROM golang:1.21
+ARG TARGETOS
+ARG TARGETARCH
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
 
+RUN sh build.sh
+
+FROM --platform=$TARGETPLATFORM alpine:3
 COPY LICENSE /
-
 COPY --from=builder /src/bin/* /usr/local/bin/
-
-ARG GIT_REPO
-ARG GIT_TAG
-ARG GIT_COMMIT
-ARG BUILD_TIMESTAMP
-
-LABEL org.opencontainers.image.url="https://github.com/${GIT_REPO}" \
-      org.opencontainers.image.documentation="https://github.com/${GIT_REPO}" \
-      org.opencontainers.image.source="https://github.com/${GIT_REPO}" \
-      org.opencontainers.image.version="${GIT_TAG}" \
-      org.opencontainers.image.revision="${GIT_COMMIT}" \
-      org.opencontainers.image.vendor='Google LLC' \
-      org.opencontainers.image.licenses='Apache-2.0' \
-      org.opencontainers.image.description='This is a tool for generating Apigee bundles and shared flows'
-
 ENTRYPOINT [ "apigee-go-gen" ]
 


### PR DESCRIPTION
Add support for both amd64 and arm64 docker images. This should allow end users on system like MacOS with Apple silicon to use the docker image.