### PR TITLE
bug: fix logic to pick latest release

### DIFF
--- a/install
+++ b/install
@@ -104,7 +104,9 @@ sortSemver() {
 pickLatestRelease() {
   local first=""
   while read version; do
-    first="${version}"
+    if [[ -z "${first}" ]] ; then
+      first="${version}"
+    fi
     if [[ "${version}" != *"-"* ]] ; then
       echo "${version}"
       return


### PR DESCRIPTION
If there are no stable releases, it should pick the most recent unstable one and choose it as the "latest".