### PR TITLE
Update mktemp directory name (Issue #11)

### DIFF
--- a/install
+++ b/install
@@ -129,7 +129,7 @@ getLatestRelease() {
 }
 
 createTmpDir() {
-   ret_val=$(mktemp -dt ${BINARY_FILENAME}-tmp)
+   ret_val=$(mktemp -dt ${BINARY_FILENAME}-XXXXXXX)
 }
 
 


### PR DESCRIPTION
Issues #11 : mktemp: too few X's in template ‘apigee-go-gen-tmp’ 

Update install script line 132, from
`  ret_val=$(mktemp -dt ${BINARY_FILENAME}-tmp)`
to
`  ret_val=$(mktemp -dt ${BINARY_FILENAME}-XXXXXXX)`