### PR TITLE
feat: add support for PostClientFlow

### DIFF
--- a/examples/templates/oas3/apiproxy.yaml
+++ b/examples/templates/oas3/apiproxy.yaml
@@ -49,6 +49,12 @@ ProxyEndpoints:
             Request:
               - Step:
                   Name: RF-CatchAll
+      PostClientFlow:
+        .name: SamplePostClientFlow
+        Description: Processed after the response is sent back to the client.
+        Response:
+          Step:
+            Name: ML-Logging-OK
       HTTPProxyConnection:
         BasePath: {{ include "get_basepath" (index $.Values.spec.servers 0 "url") }}
       RouteRule:

--- a/examples/templates/oas3/policies.yaml
+++ b/examples/templates/oas3/policies.yaml
@@ -37,3 +37,13 @@
         StatusCode: 404
         ReasonPhrase: Not found
     IgnoreUnresolvedVariables: true
+- MessageLogging:
+    .name: ML-Logging-OK
+    Syslog:
+      Message: '[3f509b58 tag="{organization.name}.{apiproxy.name}.{environment.name}"] Weather request for WOEID {request.queryparam.w}.'
+      Host: example.loggly.com
+      Port: 514
+      Protocol: TCP
+      FormatMessage: true
+      DateFormat: yyMMdd-HH:mm:ss.SSS
+    logLevel: ALERT

--- a/pkg/apigee/v1/apiproxymodel_test.go
+++ b/pkg/apigee/v1/apiproxymodel_test.go
@@ -35,6 +35,9 @@ func TestNewAPIProxyModel(t *testing.T) {
 		{
 			"simple",
 		},
+		{
+			"postclient",
+		},
 	}
 	for _, tt := range tests {
 		ttDir := filepath.Join("testdata", "yaml-first", tt.name)
@@ -50,6 +53,9 @@ func TestNewAPIProxyModel(t *testing.T) {
 			outFile := filepath.Join(ttDir, "out-apiproxy.yaml")
 
 			model, err := NewAPIProxyModel(inputFile)
+			require.NoError(t, err)
+
+			err = model.Validate()
 			require.NoError(t, err)
 
 			outData, err := model.YAML()

--- a/pkg/apigee/v1/postclientflow.go
+++ b/pkg/apigee/v1/postclientflow.go
@@ -1,0 +1,41 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import "fmt"
+
+type PostClientFlow struct {
+	Name        string    `xml:"name,attr"`
+	Description string    `xml:"Description,omitempty"`
+	Response    *Response `xml:"Response"`
+
+	UnknownNode AnyList `xml:",any"`
+}
+
+func ValidatePostClientFlow(v *PostClientFlow, path string) []error {
+	if v == nil {
+		return nil
+	}
+
+	subPath := fmt.Sprintf("%s.PostClientFlow", path)
+	if len(v.UnknownNode) > 0 {
+		return []error{&UnknownNodeError{subPath, v.UnknownNode[0]}}
+	}
+
+	var subErrors []error
+	subErrors = append(subErrors, ValidateResponse(v.Response, subPath)...)
+
+	return subErrors
+}

--- a/pkg/apigee/v1/proxyendpoint.go
+++ b/pkg/apigee/v1/proxyendpoint.go
@@ -28,6 +28,7 @@ type ProxyEndpoint struct {
 	PreFlow             *PreFlow             `xml:"PreFlow,omitempty"`
 	Flows               *Flows               `xml:"Flows,omitempty"`
 	PostFlow            *PostFlow            `xml:"PostFlow,omitempty"`
+	PostClientFlow      *PostClientFlow      `xml:"PostClientFlow,omitempty"`
 	HTTPProxyConnection *HTTPProxyConnection `xml:"HTTPProxyConnection,omitempty"`
 	RouteRules          *RouteRuleList       `xml:"RouteRule,omitempty"`
 
@@ -68,6 +69,7 @@ func ValidateProxyEndpoint(v *ProxyEndpoint, path string) []error {
 	subErrors = append(subErrors, ValidateRouteRules(v.RouteRules, subPath)...)
 	subErrors = append(subErrors, ValidateFaultRules(v.FaultRules, subPath)...)
 	subErrors = append(subErrors, ValidateDefaultFaultRule(v.DefaultFaultRule, subPath)...)
+	subErrors = append(subErrors, ValidatePostClientFlow(v.PostClientFlow, subPath)...)
 
 	return subErrors
 }

--- a/pkg/apigee/v1/testdata/yaml-first/postclient/apiproxy.yaml
+++ b/pkg/apigee/v1/testdata/yaml-first/postclient/apiproxy.yaml
@@ -1,0 +1,50 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http:#www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+APIProxy:
+  .revision: 1
+  .name: swagger-petstore
+Policies:
+  - MessageLogging:
+      .name: Message-Logging-OK
+      Syslog:
+        Message: '[3f509b58 tag="{organization.name}.{apiproxy.name}.{environment.name}"] Weather request for WOEID {request.queryparam.w}.'
+        Host: logs-01.loggly.com
+        Port: 514
+        Protocol: TCP
+        FormatMessage: true
+        DateFormat: yyMMdd-HH:mm:ss.SSS
+      logLevel: ALERT
+ProxyEndpoints:
+  - ProxyEndpoint:
+      .name: default
+      PostClientFlow:
+        .name: my-postclient-flow
+        Description: My first PostClientFlow. Processed after the response is sent back to the client.
+        Response:
+          Step:
+            Name: Message-Logging-OK
+      Flows:
+        - Flow:
+            .name: json
+            Condition: (proxy.pathsuffix MatchesPath "/json") and (request.verb = "GET")
+      HTTPProxyConnection:
+        BasePath: /httpbin
+      RouteRule:
+        .name: default
+        TargetEndpoint: default
+TargetEndpoints:
+  - TargetEndpoint:
+      .name: default
+      HTTPTargetConnection:
+        URL: https://httpbin.org


### PR DESCRIPTION
This allows the use of PostClientFLow in the YAML without getting validation errors.