### PR TITLE
feat: add support for nested template rendering

### DIFF
--- a/cmd/apigee-go-gen/main.go
+++ b/cmd/apigee-go-gen/main.go
@@ -37,6 +37,9 @@ func main() {
 		}
 
 		if showStack {
+			if isMultiErrors {
+				err = multiErrors.Errors[0]
+			}
 			_, _ = fmt.Fprintf(os.Stderr, "%s\n", errors.Wrap(err, 0).Stack())
 		}
 		os.Exit(1)

--- a/cmd/apigee-go-gen/render/apiproxy/cmd.go
+++ b/cmd/apigee-go-gen/render/apiproxy/cmd.go
@@ -26,6 +26,7 @@ import (
 )
 
 var cFlags = render.NewCommonFlags()
+var debug = flags.NewBool(false)
 var dryRun = flags.NewEnum([]string{"xml", "yaml"})
 var validate = flags.NewBool(true)
 var setValue = flags.NewSetAny(cFlags.Values)
@@ -42,7 +43,7 @@ var Cmd = &cobra.Command{
 	Short: "Generate an API proxy bundle from a template",
 	Long:  Usage(),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if strings.TrimSpace(string(cFlags.OutputFile)) == "" && dryRun.IsUnset() {
+		if strings.TrimSpace(string(cFlags.OutputFile)) == "" && dryRun.IsUnset() && bool(debug) == false {
 			return errors.New("required flag(s) \"output\" not set")
 		}
 
@@ -50,7 +51,7 @@ var Cmd = &cobra.Command{
 			return v1.NewAPIProxyModel(input)
 		}
 
-		return render.GenerateBundle(createModelFunc, cFlags, bool(validate), dryRun.Value)
+		return render.GenerateBundle(createModelFunc, cFlags, bool(validate), dryRun.Value, bool(debug))
 	},
 }
 
@@ -59,7 +60,8 @@ func init() {
 	Cmd.Flags().VarP(&cFlags.TemplateFile, "template", "t", `path to main template"`)
 	Cmd.Flags().VarP(&cFlags.IncludeList, "include", "i", `path to helper templates (globs allowed)`)
 	Cmd.Flags().VarP(&cFlags.OutputFile, "output", "o", `output directory or file`)
-	Cmd.Flags().VarP(&dryRun, "dry-run", "d", `prints rendered API proxy template to stdout"`)
+	Cmd.Flags().VarP(&debug, "debug", "", `prints rendered template before transforming into API proxy"`)
+	Cmd.Flags().VarP(&dryRun, "dry-run", "d", `prints rendered template after transforming into API Proxy"`)
 	Cmd.Flags().VarP(&validate, "validate", "v", "check for unknown elements")
 	Cmd.Flags().Var(&setValue, "set", `sets a key=value (bool,float,string), e.g. "use_ssl=true"`)
 	Cmd.Flags().Var(&setValueStr, "set-string", `sets key=value (string), e.g. "base_path=/v1/hello" `)

--- a/cmd/apigee-go-gen/render/sharedflow/cmd.go
+++ b/cmd/apigee-go-gen/render/sharedflow/cmd.go
@@ -26,6 +26,7 @@ import (
 )
 
 var cFlags = render.NewCommonFlags()
+var debug = flags.NewBool(false)
 var dryRun = flags.NewEnum([]string{"xml", "yaml"})
 var validate = flags.NewBool(true)
 var setValue = flags.NewSetAny(cFlags.Values)
@@ -42,7 +43,7 @@ var Cmd = &cobra.Command{
 	Short: "Generate a shared flow bundle from a template",
 	Long:  Usage(),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if strings.TrimSpace(string(cFlags.OutputFile)) == "" && dryRun.IsUnset() {
+		if strings.TrimSpace(string(cFlags.OutputFile)) == "" && dryRun.IsUnset() && bool(debug) == false {
 			return errors.New("required flag(s) \"output\" not set")
 		}
 
@@ -50,7 +51,7 @@ var Cmd = &cobra.Command{
 			return v1.NewSharedFlowBundleModel(input)
 		}
 
-		return render.GenerateBundle(createModelFunc, cFlags, bool(validate), dryRun.Value)
+		return render.GenerateBundle(createModelFunc, cFlags, bool(validate), dryRun.Value, bool(debug))
 	},
 }
 
@@ -59,7 +60,8 @@ func init() {
 	Cmd.Flags().VarP(&cFlags.TemplateFile, "template", "t", `path to main template"`)
 	Cmd.Flags().VarP(&cFlags.IncludeList, "include", "i", `path to helper templates (globs allowed)`)
 	Cmd.Flags().VarP(&cFlags.OutputFile, "output", "o", `output directory or file`)
-	Cmd.Flags().VarP(&dryRun, "dry-run", "d", `prints rendered template to stdout"`)
+	Cmd.Flags().VarP(&debug, "debug", "", `prints rendered template before transforming into shared flow"`)
+	Cmd.Flags().VarP(&dryRun, "dry-run", "d", `prints rendered template after transforming into shared flow"`)
 	Cmd.Flags().VarP(&validate, "validate", "v", "check for unknown elements")
 	Cmd.Flags().Var(&setValue, "set", `sets a key=value (bool,float,string), e.g. "use_ssl=true"`)
 	Cmd.Flags().Var(&setValueStr, "set-string", `sets key=value (string), e.g. "base_path=/v1/hello" `)

--- a/docs/render/commands/render-apiproxy.md
+++ b/docs/render/commands/render-apiproxy.md
@@ -39,7 +39,8 @@ The `render apiproxy` command takes the following parameters:
   -t, --template string          path to main template"
   -i, --include string           path to helper templates (globs allowed)
   -o, --output string            output directory or file
-  -d, --dry-run enum(xml|yaml)   prints rendered API proxy template to stdout"
+      --debug boolean            prints rendered template before transforming into API proxy"
+  -d, --dry-run enum(xml|yaml)   prints rendered template after transforming into API Proxy"
   -v, --validate boolean         check for unknown elements
       --set string               sets a key=value (bool,float,string), e.g. "use_ssl=true"
       --set-string string        sets key=value (string), e.g. "base_path=/v1/hello" 

--- a/docs/render/commands/render-sharedflow.md
+++ b/docs/render/commands/render-sharedflow.md
@@ -31,7 +31,8 @@ The `render sharedflow` command takes the following parameters:
   -t, --template string          path to main template"
   -i, --include string           path to helper templates (globs allowed)
   -o, --output string            output directory or file
-  -d, --dry-run enum(xml|yaml)   prints rendered template to stdout"
+      --debug boolean            prints rendered template before transforming into shared flow"
+  -d, --dry-run enum(xml|yaml)   prints rendered template after transforming into shared flow"
   -v, --validate boolean         check for unknown elements
       --set string               sets a key=value (bool,float,string), e.g. "use_ssl=true"
       --set-string string        sets key=value (string), e.g. "base_path=/v1/hello" 

--- a/docs/render/using-built-in-helpers.md
+++ b/docs/render/using-built-in-helpers.md
@@ -24,13 +24,23 @@ The template rendering commands include a set of built-in helper functions to as
  func include(template string, data any) string
 ```
 
-This function allows you to invoke your own [custom helper functions](./using-custom-helpers.md)
+This function allows you to invoke your own [custom helper functions](./using-custom-helpers.md).
 
 e.g.
 
 ```gotemplate
 {{ include "sayHello" $data }}
 ```
+
+This function can also be used to render a file.
+
+e.g.
+
+```shell
+{{ include "./path/to/file.yaml" . }}
+```
+
+> The path to template file to render is relative to the parent template file.
 
 
 ### **os_writefile**

--- a/docs/render/using-openapi-spec.md
+++ b/docs/render/using-openapi-spec.md
@@ -56,11 +56,18 @@ apigee-go-gen render apiproxy \
     --output ./out/apiproxies/petstore
 ```
 
-## Dry run
+## Dry run / Debug
 
 For rapid development, you can print the rendered template directly to stdout in your terminal. 
 
-Add the `--dry-run xml` or `--dry-run yaml` flag. e.g.
+Add the `--dry-run xml` or `--dry-run yaml` flag. 
+
+Note that dry-run is only useful when the rendered template produces valid YAML. 
+
+If your template has issues, and it does not produce valid YAML, you can use the `--debug true` flag.
+
+This will print out the rendered template before even attempting to parse it as YAML.
+
 
 === "XML output"
 ```shell

--- a/examples/templates/oas3/apiproxy.yaml
+++ b/examples/templates/oas3/apiproxy.yaml
@@ -18,14 +18,15 @@ APIProxy:
   DisplayName: {{ $.Values.spec.info.title }}
   Description: |- 
     {{ $.Values.spec.info.description | nindent 4 }}
-Policies:
-  $ref: ./policies.yaml#/
+Policies: {{ include "./policies.yaml" . | nindent 2 }}
 ProxyEndpoints:
   - ProxyEndpoint:
       .name: default
       PreFlow:
         .name: PreFlow
         Request:
+          - Step:
+              Name: Spike-Arrest
           - Step:
               Name: OAS-Validate
       Flows:

--- a/examples/templates/oas3/policies.yaml
+++ b/examples/templates/oas3/policies.yaml
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
----
+
 - OASValidation:
     .continueOnError: false
     .enabled: true
@@ -37,13 +37,5 @@
         StatusCode: 404
         ReasonPhrase: Not found
     IgnoreUnresolvedVariables: true
-- MessageLogging:
-    .name: ML-Logging-OK
-    Syslog:
-      Message: '[3f509b58 tag="{organization.name}.{apiproxy.name}.{environment.name}"] Weather request for WOEID {request.queryparam.w}.'
-      Host: example.loggly.com
-      Port: 514
-      Protocol: TCP
-      FormatMessage: true
-      DateFormat: yyMMdd-HH:mm:ss.SSS
-    logLevel: ALERT
+- {{ include "./policies/message-logging.yaml" . | indent 2 | trim }}
+- {{ include "./policies/spike-arrest.yaml" . | indent 2 | trim }}

--- a/examples/templates/oas3/policies/message-logging.yaml
+++ b/examples/templates/oas3/policies/message-logging.yaml
@@ -1,0 +1,23 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http:#www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+MessageLogging:
+  .name: ML-Logging-OK
+  Syslog:
+    Message: '[3f509b58 tag="{organization.name}.{apiproxy.name}.{environment.name}"] Weather request for WOEID {request.queryparam.w}.'
+    Host: example.loggly.com
+    Port: 514
+    Protocol: TCP
+    FormatMessage: true
+    DateFormat: yyMMdd-HH:mm:ss.SSS
+  logLevel: ALERT

--- a/examples/templates/oas3/policies/spike-arrest.yaml
+++ b/examples/templates/oas3/policies/spike-arrest.yaml
@@ -1,0 +1,25 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http:#www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+SpikeArrest:
+  .continueOnError: false
+  .enabled: true
+  .name: Spike-Arrest
+  DisplayName: Spike Arrest
+  Properties: {}
+  Identifier:
+    .ref: client.ip
+  # The example below sets the Rate value dynamically from the render context
+  # You can pass the value like this --set spike_arrest_rate=300pm in the command line
+  # If the value is unset, it defaults to 100pm
+  Rate: {{ or ($.Values.spike_arrest_rate) "100pm" }}

--- a/pkg/common/resources/helper_functions.txt
+++ b/pkg/common/resources/helper_functions.txt
@@ -1,5 +1,18 @@
     include(template string, data any)
-        Invoke an existing template e.g {{ include "sayHello" $data }}
+        Render a pre-defined template, e.g.
+
+          {{ include "greet" "Miguel" }}
+
+        The template must be defined ahead of time with a "define" block, e.g.
+
+          {{- define "greet" -}}
+            {{- $name := . -}}
+            Hello {{ $name }} !
+          {{- end -}}
+
+        You can also use this function to render an existing file. e.g.
+
+          {{ include "./path/to/file.yaml" . }}
 
     os_writefile(dest string, content string)
         Write a file to the output directory

--- a/pkg/render/model.go
+++ b/pkg/render/model.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 )
 
-func GenerateBundle(createModelFunc func(string) (v1.Model, error), cFlags *CommonFlags, validate bool, dryRun string) error {
+func GenerateBundle(createModelFunc func(string) (v1.Model, error), cFlags *CommonFlags, validate bool, dryRun string, debug bool) error {
 	var err error
 
 	bundleOutputFile := cFlags.OutputFile
@@ -51,9 +51,17 @@ func GenerateBundle(createModelFunc func(string) (v1.Model, error), cFlags *Comm
 		return errors.New(err)
 	}
 
+	if debug {
+		fmt.Println(string(rendered))
+		return nil
+	}
+
 	rendered, err = ResolveYAML(rendered, templateFile)
 	if err != nil {
-		return err
+		return utils.MultiError{
+			Errors: []error{
+				err,
+				errors.New("rendered template appears to not be valid YAML. Use --debug=true flag to inspect rendered output")}}
 	}
 
 	err = os.WriteFile(string(cFlags.OutputFile), rendered, os.ModePerm)

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -1,0 +1,115 @@
+//  Copyright 2024 Google LLC
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package render
+
+import (
+	"fmt"
+	"github.com/apigee/apigee-go-gen/pkg/flags"
+	"github.com/apigee/apigee-go-gen/pkg/utils"
+	"github.com/stretchr/testify/require"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+)
+
+func TestRenderGeneric(t *testing.T) {
+
+	tests := []struct {
+		dir          string
+		templateFile string
+		valuesFile   string
+		includesFile string
+		wantErr      error
+	}{
+		{
+			"using-files",
+			"input.yaml",
+			"",
+			"",
+			nil,
+		},
+		{
+			"using-helpers",
+			"input.yaml",
+			"",
+			"_helpers.tmpl",
+			nil,
+		},
+		{
+			"policies",
+			"apiproxy.yaml",
+			"values.yaml",
+			"",
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.dir, func(t *testing.T) {
+
+			testDir := path.Join("testdata", "render", tt.dir)
+			templateFile := path.Join(testDir, tt.templateFile)
+
+			outputFile := path.Join(testDir, fmt.Sprintf("out-%s", tt.templateFile))
+			expectedFile := path.Join(testDir, fmt.Sprintf("exp-%s", tt.templateFile))
+
+			var err error
+			err = os.RemoveAll(outputFile)
+			require.NoError(t, err)
+
+			type ctx struct{}
+			cFlags := NewCommonFlags()
+			cFlags.TemplateFile = flags.String(templateFile)
+			cFlags.OutputFile = flags.String(outputFile)
+
+			if tt.valuesFile != "" {
+				v := flags.NewValues(cFlags.Values)
+				valuesFile := path.Join(testDir, tt.valuesFile)
+				err := v.Set(valuesFile)
+				require.NoError(t, err)
+			}
+
+			if tt.includesFile != "" {
+				includesFile := path.Join(testDir, tt.includesFile)
+				err := cFlags.IncludeList.Set(includesFile)
+				require.NoError(t, err)
+			}
+
+			err = RenderGenericTemplate(cFlags, false)
+
+			if tt.wantErr != nil {
+				require.EqualError(t, err, tt.wantErr.Error())
+				return
+			}
+			require.NoError(t, err)
+
+			outputBytes := utils.MustReadFileBytes(outputFile)
+			expectedBytes := utils.MustReadFileBytes(expectedFile)
+
+			if filepath.Ext(expectedFile) == ".txt" {
+				require.Equal(t, string(expectedBytes), string(outputBytes))
+			} else if filepath.Ext(expectedFile) == ".json" {
+				require.JSONEq(t, string(expectedBytes), string(outputBytes))
+			} else if filepath.Ext(expectedFile) == ".yaml" {
+				outputBytes = utils.RemoveYAMLComments(outputBytes)
+				expectedBytes = utils.RemoveYAMLComments(expectedBytes)
+				require.YAMLEq(t, string(expectedBytes), string(outputBytes))
+			} else {
+				t.Error("unknown output format in testcase")
+			}
+
+		})
+	}
+}

--- a/pkg/render/testdata/.gitignore
+++ b/pkg/render/testdata/.gitignore
@@ -1,0 +1,15 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http:#www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+**/out-*

--- a/pkg/render/testdata/render/policies/apiproxy.yaml
+++ b/pkg/render/testdata/render/policies/apiproxy.yaml
@@ -1,0 +1,19 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http:#www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+APIProxy:
+  .revision: 1
+  .name: Example
+  DisplayName: Example
+  Description: Example
+Policies: {{ include "policies.yaml" . | nindent 2 }}

--- a/pkg/render/testdata/render/policies/common/assign-message.yaml
+++ b/pkg/render/testdata/render/policies/common/assign-message.yaml
@@ -1,0 +1,29 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http:#www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+AssignMessage:
+  .continueOnError: false
+  .enabled: true
+  .name: AM-SetHeader
+  DisplayName: AM-SetHeader
+  Properties: {}
+  Set:
+    Headers:
+      Header:
+        .name: Example
+        -Data: {{ $.Values.example_header }}
+  IgnoreUnresolvedVariables: true
+  AssignTo:
+    .createNew: false
+    .transport: http
+    .type: request

--- a/pkg/render/testdata/render/policies/common/spike-arrest.yaml
+++ b/pkg/render/testdata/render/policies/common/spike-arrest.yaml
@@ -1,0 +1,22 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http:#www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+SpikeArrest:
+  .continueOnError: false
+  .enabled: true
+  .name: Spike-Arrest
+  DisplayName: Spike Arrest
+  Properties: {}
+  Identifier:
+    .ref: {{ $.Values.spike_arrest.identifier }}
+  Rate: {{ or ($.Values.spike_arrest.rate) "100pm" }}

--- a/pkg/render/testdata/render/policies/exp-apiproxy.yaml
+++ b/pkg/render/testdata/render/policies/exp-apiproxy.yaml
@@ -1,0 +1,44 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http:#www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+APIProxy:
+  .revision: 1
+  .name: Example
+  DisplayName: Example
+  Description: Example
+Policies:
+  - SpikeArrest:
+      .continueOnError: false
+      .enabled: true
+      .name: Spike-Arrest
+      DisplayName: Spike Arrest
+      Properties: {}
+      Identifier:
+        .ref: client.ip
+      Rate: 400pm
+  - AssignMessage:
+      .continueOnError: false
+      .enabled: true
+      .name: AM-SetHeader
+      DisplayName: AM-SetHeader
+      Properties: {}
+      Set:
+        Headers:
+          Header:
+            .name: Example
+            -Data: example_value
+      IgnoreUnresolvedVariables: true
+      AssignTo:
+        .createNew: false
+        .transport: http
+        .type: request

--- a/pkg/render/testdata/render/policies/policies.yaml
+++ b/pkg/render/testdata/render/policies/policies.yaml
@@ -1,0 +1,15 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http:#www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+- {{ include "./common/spike-arrest.yaml" . | indent 2 | trim }}
+- {{ include "./common/assign-message.yaml" . | indent 2 | trim }}

--- a/pkg/render/testdata/render/policies/values.yaml
+++ b/pkg/render/testdata/render/policies/values.yaml
@@ -1,0 +1,17 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http:#www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+spike_arrest:
+  rate: 400pm
+  identifier: client.ip
+example_header: example_value

--- a/pkg/render/testdata/render/using-files/exp-input.yaml
+++ b/pkg/render/testdata/render/using-files/exp-input.yaml
@@ -1,0 +1,15 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http:#www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+The quick brown fox jumped over the lazy dog

--- a/pkg/render/testdata/render/using-files/input.yaml
+++ b/pkg/render/testdata/render/using-files/input.yaml
@@ -1,0 +1,15 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http:#www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+The quick brown {{ include "./level1/input.yaml" }}

--- a/pkg/render/testdata/render/using-files/level1/input.yaml
+++ b/pkg/render/testdata/render/using-files/level1/input.yaml
@@ -1,0 +1,1 @@
+fox jumped over {{ include "./level2/input.yaml" }}

--- a/pkg/render/testdata/render/using-files/level1/level2/input.yaml
+++ b/pkg/render/testdata/render/using-files/level1/level2/input.yaml
@@ -1,0 +1,1 @@
+the lazy dog

--- a/pkg/render/testdata/render/using-helpers/_helpers.tmpl
+++ b/pkg/render/testdata/render/using-helpers/_helpers.tmpl
@@ -1,0 +1,23 @@
+{{/*
+ Copyright 2024 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http:#www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/}}
+
+{{- define "level1" -}}
+  fox jumped over {{ include "level2" }}
+{{- end -}}
+
+{{- define "level2" -}}
+  the lazy dog
+{{- end -}}

--- a/pkg/render/testdata/render/using-helpers/exp-input.yaml
+++ b/pkg/render/testdata/render/using-helpers/exp-input.yaml
@@ -1,0 +1,15 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http:#www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+The quick brown fox jumped over the lazy dog

--- a/pkg/render/testdata/render/using-helpers/input.yaml
+++ b/pkg/render/testdata/render/using-helpers/input.yaml
@@ -1,0 +1,15 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http:#www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+The quick brown {{ include "level1" . }}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-errors/errors"
 	"gopkg.in/yaml.v3"
 	"os"
+	"regexp"
 )
 
 func MustReadFileBytes(path string) []byte {
@@ -83,4 +84,10 @@ func PushDir(dir string) func() {
 	}
 
 	return popDir
+}
+
+func RemoveYAMLComments(data []byte) []byte {
+	regex := regexp.MustCompile(`(?ms)^\s*#[^\n\r]*$[\r\n]*`)
+	replaced := regex.ReplaceAll(data, []byte{})
+	return replaced
 }

--- a/pkg/utils/xml_test.go
+++ b/pkg/utils/xml_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"github.com/stretchr/testify/assert"
 	"path/filepath"
-	"regexp"
 	"testing"
 )
 
@@ -82,10 +81,4 @@ func TestXMLText2YAMLText(t *testing.T) {
 			assert.Equal(t, string(wantBytes), string(gotBytes))
 		})
 	}
-}
-
-func RemoveYAMLComments(data []byte) []byte {
-	regex := regexp.MustCompile(`(?ms)^\s*#[^\n\r]*$[\r\n]*`)
-	replaced := regex.ReplaceAll(data, []byte{})
-	return replaced
 }


### PR DESCRIPTION
Up to now, you could only templetize the main file, or define helper functions.

This change makes it so that you can render any arbitrary file like this:

{{ include "./path/to/file.yaml" . }}

This is useful for dynamically generating policies without having to in-line them in the main template.

Also, add a `--debug=true` flag to help users troubleshoot template rendering