### PR TITLE
fix: set-file was not reading file content

### DIFF
--- a/pkg/flags/setfile.go
+++ b/pkg/flags/setfile.go
@@ -25,8 +25,8 @@ type SetFile struct {
 	Data *values.Map
 }
 
-func NewSetFile(data *values.Map) SetString {
-	return SetString{Data: data}
+func NewSetFile(data *values.Map) SetFile {
+	return SetFile{Data: data}
 }
 
 func (v *SetFile) Type() string {
@@ -48,6 +48,6 @@ func (v *SetFile) Set(entry string) error {
 		return errors.New(err)
 	}
 
-	v.Data.Set(key, fileText)
+	v.Data.Set(key, string(fileText))
 	return nil
 }

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -32,11 +33,13 @@ func TestRenderGeneric(t *testing.T) {
 		templateFile string
 		valuesFile   string
 		includesFile string
+		setFileFlag  string
 		wantErr      error
 	}{
 		{
 			"using-files",
 			"input.yaml",
+			"",
 			"",
 			"",
 			nil,
@@ -46,6 +49,7 @@ func TestRenderGeneric(t *testing.T) {
 			"input.yaml",
 			"",
 			"_helpers.tmpl",
+			"",
 			nil,
 		},
 		{
@@ -53,6 +57,15 @@ func TestRenderGeneric(t *testing.T) {
 			"apiproxy.yaml",
 			"values.yaml",
 			"",
+			"",
+			nil,
+		},
+		{
+			"set-file",
+			"input.yaml",
+			"",
+			"",
+			"data=./data.json",
 			nil,
 		},
 	}
@@ -84,6 +97,14 @@ func TestRenderGeneric(t *testing.T) {
 			if tt.includesFile != "" {
 				includesFile := path.Join(testDir, tt.includesFile)
 				err := cFlags.IncludeList.Set(includesFile)
+				require.NoError(t, err)
+			}
+
+			if tt.setFileFlag != "" {
+				key, filePath, _ := strings.Cut(tt.setFileFlag, "=")
+				tt.setFileFlag = fmt.Sprintf("%s=%s", key, path.Join(testDir, filePath))
+				f := flags.NewSetFile(cFlags.Values)
+				err := f.Set(tt.setFileFlag)
 				require.NoError(t, err)
 			}
 

--- a/pkg/render/testdata/render/set-file/data.json
+++ b/pkg/render/testdata/render/set-file/data.json
@@ -1,0 +1,5 @@
+[
+  {
+    "name": "hello world"
+  }
+]

--- a/pkg/render/testdata/render/set-file/exp-input.yaml
+++ b/pkg/render/testdata/render/set-file/exp-input.yaml
@@ -1,0 +1,15 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http:#www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+name: hello world

--- a/pkg/render/testdata/render/set-file/input.yaml
+++ b/pkg/render/testdata/render/set-file/input.yaml
@@ -1,0 +1,16 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http:#www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+#{{ $data := index ($.Values.data | fromJson) 0 }}
+name: {{ $data.name }}


### PR DESCRIPTION
There was a bug where the contents of the file were not being read, and instead only the file name was being set.
This fix makes it so that the actual file contents are read and set into the specified key within the $.Values context.